### PR TITLE
콜금리 2005~2017년 남기기

### DIFF
--- a/2. Pre-processing and Feature Selection/call_rate_labeling.py
+++ b/2. Pre-processing and Feature Selection/call_rate_labeling.py
@@ -61,11 +61,9 @@ for i, diff in enumerate(value_diff):
     elif diff < 0:
         fin_df['label'][i] = 'down'   
 
+# 7. 2005년 ~ 2017년만 남기기
+fin_df = fin_df.loc['2005.01.01':'2017.12.31', :]
 fin_df.reset_index(inplace=True)
-
-
-# 7. 2005년 이전 데이터 없애기
-fin_df = fin_df.loc[33:,:]
 
 fin_df.to_csv('call_rate_finish.csv',index=False)
 print('finish!')


### PR DESCRIPTION
콜금리 데이터 2005년 1월 1일부터 2017년 12월 31일까지의 데이터만 남기는 코드 추가